### PR TITLE
feat: reimplement storage class with hashicorp/kubernetes provider

### DIFF
--- a/storage-class.tf
+++ b/storage-class.tf
@@ -1,11 +1,8 @@
-resource "kubectl_manifest" "storage_class" {
-  count      = (var.enabled && var.create_storage_class) ? 1 : 0
-  yaml_body  = <<YAML
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: ${var.storage_class_name}
-provisioner: efs.csi.aws.com
-YAML
-  depends_on = [helm_release.kubernetes_efs_csi_driver]
+resource "kubernetes_storage_class" "storage_class" {
+  count = (var.enabled && var.create_storage_class) ? 1 : 0
+  metadata {
+    name = var.storage_class_name
+  }
+  storage_provisioner = "efs.csi.aws.com"
+  depends_on          = [helm_release.kubernetes_efs_csi_driver]
 }

--- a/versions.tf
+++ b/versions.tf
@@ -5,9 +5,5 @@ terraform {
     aws        = ">= 3.13, < 4.0"
     helm       = ">= 1.0, < 3.0"
     kubernetes = ">= 1.10.0, < 3.0.0"
-    kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.9.4"
-    }
   }
 }


### PR DESCRIPTION
Fixes #8 

Motivation in our internal CICD system the kubectl provider was not working properly and we want to use an official provider for doing that functionality.

It is not a breaking change but It will destroy the storage class and create another one with the same name.
This was tested on my internal EKS cluster and everything worked properly.



## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the CONTRIBUTING.md doc.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.
