### PR TITLE
[IAM Policy] adds elasticfilesystem:TagResource permission

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -27,6 +27,19 @@ data "aws_iam_policy_document" "efs_csi_driver" {
 
   statement {
     actions = [
+      "elasticfilesystem:CreateAccessPoint"
+    ]
+    resources = ["*"]
+    effect    = "Allow"
+    condition {
+      test     = "StringLike"
+      variable = "aws:RequestTag/efs.csi.aws.com/cluster"
+      values   = ["true"]
+    }
+  }
+
+  statement {
+    actions = [
       "elasticfilesystem:DeleteAccessPoint"
     ]
     resources = ["*"]

--- a/iam.tf
+++ b/iam.tf
@@ -27,13 +27,13 @@ data "aws_iam_policy_document" "efs_csi_driver" {
 
   statement {
     actions = [
-      "elasticfilesystem:CreateAccessPoint"
+      "elasticfilesystem:TagResource"
     ]
     resources = ["*"]
     effect    = "Allow"
     condition {
       test     = "StringLike"
-      variable = "aws:RequestTag/efs.csi.aws.com/cluster"
+      variable = "aws:ResourceTag/efs.csi.aws.com/cluster"
       values   = ["true"]
     }
   }


### PR DESCRIPTION
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes
Extends the IAM Policy to add the following permission to match to what is in main Helm chart:
https://github.com/kubernetes-sigs/aws-efs-csi-driver/commit/cd41c38c9902505e14337d4967f929027ce6c417

For some reason efs-csi-driver fails to create EFS AP on some of my clusters, while it still works on others. Can't really understand the difference but adding the above to IAM Policy fixes it, so since that shouldn't cause any harm I propose to add this to the official tf provider which you maintain. 

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the CONTRIBUTING.md doc.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...