### PR TITLE
FIX added tagresource permission to iam policy

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -37,6 +37,19 @@ data "aws_iam_policy_document" "efs_csi_driver" {
       values   = ["true"]
     }
   }
+
+  statement {
+    actions = [
+      "elasticfilesystem:TagResource"
+    ]
+    resources = ["*"]
+    effect    = "Allow"
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/efs.csi.aws.com/cluster"
+      values   = ["true"]
+    }
+  }
 }
 
 resource "aws_iam_policy" "efs_csi_driver" {


### PR DESCRIPTION
An action is added to the IAM policy.

As per [this](https://repost.aws/knowledge-center/eks-persistent-volume-object) AWS page on troubleshooting Amazon EFS CSI controller, under the "Access Denied" section, they refer to [this](https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/master/docs/iam-policy-example.json) policy template. 

As per this template this action is needed:

```hcl
    {
      "Effect": "Allow",
      "Action": [
        "elasticfilesystem:TagResource"
      ],
      "Resource": "*",
      "Condition": {
        "StringLike": {
          "aws:ResourceTag/efs.csi.aws.com/cluster": "true"
        }
      }
    },
```

This action is not in the module right now.

I created the driver using the module as it is and it failed due to:

```
failed to provision volume with StorageClass "<STORAGE_CLASS_NAME>": rpc error: code = Unauthenticated desc = Access Denied. Please ensure you have the right AWS permissions: Access denied
```

I added the action and it worked ok.

## Types of changes

What types of changes does your code introduce to terraform-aws-eks-efs-csi-driver?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

N/A